### PR TITLE
Configuration of Jest for DICOM Viewer package 

### DIFF
--- a/tests/unit/config/jest.config.ts
+++ b/tests/unit/config/jest.config.ts
@@ -3,7 +3,17 @@ import { compilerOptions } from '../../../vite.config'
 const rootDir = path.resolve(__dirname, '../../../')
 
 // We need to transpile these modules as they are using esm syntax
-const esmModules = ['lodash-es', 'mark.js', 'fuse.js', 'filesize'].map((m) => `.pnpm/${m}@.*`)
+const esmModules = [
+  'lodash-es',
+  'mark.js',
+  'fuse.js',
+  'filesize',
+  '@kitware\\+vtk.js',
+  'd3-array',
+  'd3-scale',
+  'd3-time',
+  'internmap'
+].map((m) => `.pnpm/${m}@.*`)
 process.env.TZ = 'GMT'
 module.exports = {
   globals: {


### PR DESCRIPTION

## Description
The module given below needed to be transpiled to ES modules as commonJS modules were not supported by jest(Jest could not parse).So, in this pr the modules are kept for transpilation.
- @kitware\\+vtk.js
-   d3-array
-   d3-scale
-   d3-time
-   internmap

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/koebel/web/pull/1

